### PR TITLE
Ensure string(::InlineString) returns String

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -295,7 +295,7 @@ end
 end
 
 const BaseStrs = Union{Char, String, SubString{String}}
-Base.string(a::InlineString) = a
+Base.string(a::InlineString) = String(a)
 Base.string(a::InlineString...) = _string(a...)
 Base.string(a::BaseStrs, b::InlineString) = _string(a, b)
 Base.string(a::BaseStrs, b::BaseStrs, c::InlineString) = _string(a, b, c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,10 @@ x = InlineString7(buf, 1, 3)
 # https://github.com/JuliaData/WeakRefStrings.jl/issues/88
 @test InlineString(String1("a")) === String1("a")
 
+# https://github.com/JuliaData/InlineStrings.jl/issues/2
+x = InlineString("hey")
+@test typeof(string(x)) == String
+
 end # @testset
 
 @testset "InlineString operations" begin


### PR DESCRIPTION
Fixes the type instability mentioned in
https://github.com/JuliaData/InlineStrings.jl/issues/2.